### PR TITLE
Added printer-driver-brlaser

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -7,7 +7,8 @@ RUN install_packages \
     avahi-daemon \
     dbus \
     libnss-mdns \
-    foomatic-db-compressed-ppds 
+    foomatic-db-compressed-ppds \
+    printer-driver-brlaser
 
 # Add script
 COPY run.sh /


### PR DESCRIPTION
CUPS filter driver supporting (some) Brother laser printers.

This driver has been reported to work with these printers:

 * Brother DCP-1510
 * Brother DCP-1602
 * Brother DCP-7030
 * Brother DCP-7040
 * Brother DCP-7055
 * Brother DCP-7055W
 * Brother DCP-7060D
 * Brother DCP-7065DN
 * Brother DCP-7080
 * Brother DCP-L2500D
 * Brother DCP-L2540DW
 * Brother HL-1110 series
 * Brother HL-1200 series
 * Brother HL-L2300D series
 * Brother HL-L2320D series
 * Brother HL-L2340D series
 * Brother HL-L2360D series
 * Brother MFC-1910W
 * Brother MFC-7240
 * Brother MFC-7360N
 * Brother MFC-7365DN
 * Brother MFC-7840W
 * Brother MFC-L2710DW
 * Lenovo M7605D