### PR TITLE
Add hplip and enable remote printing

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -7,7 +7,8 @@ RUN install_packages \
     avahi-daemon \
     dbus \
     libnss-mdns \
-    foomatic-db-compressed-ppds 
+    foomatic-db-compressed-ppds \
+    hplip
 
 # Add script
 COPY run.sh /

--- a/cups/cupsd.conf
+++ b/cups/cupsd.conf
@@ -7,6 +7,7 @@ PageLogFormat
 # Listen on Port 80
 Listen 80
 Listen 631
+
 Listen /run/cups/cups.sock
 
 # Modify ServerAlias
@@ -25,8 +26,9 @@ WebInterface Yes
 
 # Open access to the server
 <Location />
+  # Allow remote access...
   Order allow,deny
-  Allow from 52.4.252.97
+  Allow all
 </Location>
 
 # Open access to the admin pages

--- a/cups/run.sh
+++ b/cups/run.sh
@@ -8,4 +8,5 @@ iptables -A INPUT -i resin-vpn -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -p tcp --dport 80 -i resin-vpn -j ACCEPT
 iptables -A INPUT -p tcp --dport 80 -j REJECT
 
-cupsd -f
+echo "Starting CUPS"
+cupsd -f 


### PR DESCRIPTION
- Enable printer sharing and allow printing from internet in Server settings by default
- Add a startup message
- Add `hplip` package which provides support for numerous popular hp printers

closes #1 