### PR TITLE
Swap the order of Listen directives in cupsd.conf

### DIFF
--- a/cups/cupsd.conf
+++ b/cups/cupsd.conf
@@ -5,8 +5,8 @@ LogLevel warn
 PageLogFormat
 
 # Listen on Port 80
-Listen 80
 Listen 631
+Listen 80
 
 Listen /run/cups/cups.sock
 


### PR DESCRIPTION
The project currently doesn not work properly with all android devices.
The print service on the android device is able to discover the printer
but cannot query additional info. Using `Listen 631` before `Listen 80`
resolves this.

Signed-off-by: Rahul Thakoor <rahul@balena.io>