### PR TITLE
Add autoconfiguration of HP network printers

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -9,7 +9,8 @@ RUN install_packages \
     libnss-mdns \
     foomatic-db-compressed-ppds \
     printer-driver-brlaser \
-    hplip
+    hplip \
+    hplip-data
 
 # Add script
 COPY run.sh /
@@ -19,6 +20,9 @@ ENV UDEV 1
 
 # Add cupsd.conf file
 COPY cupsd.conf /etc/cups/cupsd.conf
+
+# Link DBUS file where hp-setup expects it
+RUN ln -s /host/run/dbus /var/run/dbus
 
 #Run Script
 CMD ["bash", "run.sh"]

--- a/cups/run.sh
+++ b/cups/run.sh
@@ -9,4 +9,32 @@ iptables -A INPUT -p tcp --dport 80 -i resin-vpn -j ACCEPT
 iptables -A INPUT -p tcp --dport 80 -j REJECT
 
 echo "Starting CUPS"
-cupsd -f 
+cupsd -f &
+
+
+echo "Configuring HP Printers"
+if [[ -n "$HP_IP_PRINTERS" ]]; then
+  printers=$(echo $HP_IP_PRINTERS | tr ";" "\n")
+  for printer in $printers
+  do
+    echo "Make URI for $printer"
+    url=$(hp-makeuri -c $printer)
+    if [ $? -eq 0 ]; then
+      echo "Found URL: $url"
+      echo "Checking to see if printer is in CUPS already"
+      lpstat -v | grep -Fe "$url"
+      if [ $? -ne 0 ]; then
+        echo "Configuring [$printer]"
+        hp-setup -i -a -x $printer
+      else
+        echo "Printer $printer already in CUPS with url: $url"
+      fi
+    else
+      echo "Couldn't find printer on network: $printer"
+    fi 
+  done
+else
+  echo "No HP IP Printers to configure"
+fi
+
+wait


### PR DESCRIPTION
- Adds a link to put the DBUS socket where HPLIP utilities expect it.
- Uses Device Variable HP_IP_PRINTERS to automatically configure a comma separated list of network connected HP printers.
- Will add any not yet configured printers at restart
- Handles being restarted without creating duplicates
- Does not remove already configured printers even if you remove them from the device variable.