### PR TITLE
Add Splix support

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -10,7 +10,22 @@ RUN install_packages \
     foomatic-db-compressed-ppds \
     printer-driver-brlaser \
     hplip \
-    hplip-data
+    hplip-data \
+    libcups2-dev \
+    build-essential 
+
+# Add support for Samsung printers via Splix
+WORKDIR /usr/src/app
+
+RUN git clone https://gitlab.com/ScumCoder/splix.git
+
+WORKDIR /usr/src/app/splix/splix
+
+RUN sudo make DISABLE_JBIG=1 && \
+    sudo make install && \
+    cp ./ppd/m2020.ppd /usr/share/ppd/custom
+
+WORKDIR /
 
 # Add script
 COPY run.sh /


### PR DESCRIPTION
This PR adds support for Samsung printers by installing [Splix drivers](http://splix.ap2c.org/). Tested with RPi 3b and Samsung M2026W.