### PR TITLE
Update Dockerfile.template

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -8,6 +8,7 @@ RUN install_packages \
     dbus \
     libnss-mdns \
     foomatic-db-compressed-ppds \
+    printer-driver-gutenprint \
     printer-driver-brlaser \
     hplip \
     hplip-data \


### PR DESCRIPTION
Added printer-driver-gutenprint. Gutenprint has more than 1,300 drivers for Apollo, Apple, Brother, Canon, Citizen, Compaq, Dai Nippon, DEC, Epson, Fujifilm, Fujitsu, Gestetner, HP, IBM, Infotec, Kodak, Kyocera, Lanier, Lexmark, Minolta, NEC, NRG, Oki, Olivetti, Olympus, Panasonic, PCPI, Raven, Ricoh, Samsung, Savin, Seiko, Sharp, Shinko, Sony, Star, Tally, Tektronix and Xerox printers.